### PR TITLE
add default timeout to avoid hanging while flushing

### DIFF
--- a/client/borda.go
+++ b/client/borda.go
@@ -106,6 +106,7 @@ func NewClient(opts *Options) *Client {
 					ClientSessionCache: tls.NewLRUClientSessionCache(100),
 				},
 			},
+			Timeout: time.Second * 10,
 		}
 	}
 	if opts.BeforeSubmit == nil {


### PR DESCRIPTION
This should help with https://github.com/getlantern/lantern-internal/issues/1542 and the test hangs here:

https://github.com/getlantern/flashlight/pull/404